### PR TITLE
BJ-1004: Refactor to custom metrics starter

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-build('spring-boot-starter-metrics-statsd', 'docker-host') {
+build('custom-metrics-spring-boot-starter', 'docker-host') {
     checkoutRepo()
     loadBuildUtils()
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,39 @@
-# starter for statsd metrics
+# Starter for StatsD and Prometheus custom metrics
 
-Нужно указать параметры в application.properties
+Для включения экспорта метрик указать параметры в `application.yml`.
 
+## StatsD
+
+``` yaml
+management:
+    metrics:
+        export:
+            statsd:
+                enabled: true
+                flavor: etsy
+                # specify StatsD address
+                host: changeit 
+                port: 8125
 ```
-spring.application.name=SERVICE_NAME
-management.metrics.export.statsd.enabled=true
-management.metrics.export.statsd.flavor=etsy
-management.metrics.export.statsd.host=STATSD_ADDRESS
-management.metrics.export.statsd.port=8125
+
+## Prometheus
+
+``` yaml
+management:
+    server:
+        # optional – use 8022 for backward compatibility with wetkitty
+        port: 8023 
+    endpoint: 
+        metrics:
+            enavled: true
+        prometheus:
+            enabled: true
+    endpoints:
+        web:
+            exposure:
+                include: health,info,prometheus
+    metrics:
+        export:
+            prometheus:
+                enabled: true
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -10,13 +10,13 @@
         <version>1.0.5</version>
     </parent>
 
-    <artifactId>spring-boot-starter-metrics-statsd</artifactId>
-    <version>1.1.3</version>
+    <artifactId>custom-metrics-spring-boot-starter</artifactId>
+    <version>1.1.4</version>
     <packaging>jar</packaging>
 
-    <name>Spring boot starter metrics statsd</name>
-    <description>Starter for statsd metrics</description>
-    <url>https://github.com/rbkmoney/spring-boot-starter-metrics-statsd.git</url>
+    <name>Custom metrics Spring Boot starter</name>
+    <description>Starter for StatsD and Prometheus custom metrics</description>
+    <url>https://github.com/rbkmoney/custom-metrics-spring-boot-starter.git</url>
 
     <developers>
         <developer>
@@ -28,14 +28,15 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git://github.com/rbkmoney/spring-boot-starter-metrics-statsd.git</connection>
-        <developerConnection>scm:git:ssh://github.com/rbkmoney/spring-boot-starter-metrics-statsd.git</developerConnection>
-        <url>https://github.com/rbkmoney/spring-boot-starter-metrics-statsd/tree/master</url>
+        <connection>scm:git:git://github.com/rbkmoney/custom-metrics-spring-boot-starter.git</connection>
+        <developerConnection>scm:git:ssh://github.com/rbkmoney/custom-metrics-spring-boot-starter.git</developerConnection>
+        <url>https://github.com/rbkmoney/custom-metrics-spring-boot-starter/tree/master</url>
     </scm>
 
     <properties>
         <spring.version>2.3.4.RELEASE</spring.version>
         <java.version>8</java.version>
+        <micrometer.version>1.5.6</micrometer.version>
     </properties>
 
     <dependencies>
@@ -56,7 +57,6 @@
             <version>${spring.version}</version>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
@@ -65,7 +65,17 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-statsd</artifactId>
-            <version>1.3.1</version>
+            <version>${micrometer.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <version>${micrometer.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <version>${micrometer.version}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>custom-metrics-spring-boot-starter</artifactId>
-    <version>1.1.4</version>
+    <version>1.2.0</version>
     <packaging>jar</packaging>
 
     <name>Custom metrics Spring Boot starter</name>

--- a/src/main/java/com/rbkmoney/metrics/CustomMetricBinder.java
+++ b/src/main/java/com/rbkmoney/metrics/CustomMetricBinder.java
@@ -1,4 +1,4 @@
-package com.rbkmoney.metrics.statsd;
+package com.rbkmoney.metrics;
 
 import com.sun.management.GarbageCollectorMXBean;
 import com.sun.management.OperatingSystemMXBean;

--- a/src/main/java/com/rbkmoney/metrics/MetricsAutoConfig.java
+++ b/src/main/java/com/rbkmoney/metrics/MetricsAutoConfig.java
@@ -1,4 +1,4 @@
-package com.rbkmoney.metrics.statsd;
+package com.rbkmoney.metrics;
 
         import io.micrometer.core.instrument.MeterRegistry;
         import org.springframework.beans.factory.annotation.Value;
@@ -8,7 +8,7 @@ package com.rbkmoney.metrics.statsd;
         import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class StatsdMetricsAutoConfig {
+public class MetricsAutoConfig {
 
     @Bean
     @ConditionalOnMissingBean

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,2 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.rbkmoney.metrics.statsd.StatsdMetricsAutoConfig
+com.rbkmoney.metrics.MetricsAutoConfig


### PR DESCRIPTION
Подружил прометеус и статсД. Теперь предлагаю переименовать этот проект в `custom-metrics-spring-boot-starter` и использовать его для включения нужных метрик.